### PR TITLE
Remove async/await and fix file close in wrtiablestream

### DIFF
--- a/lib/api/src/createWriteStream.js
+++ b/lib/api/src/createWriteStream.js
@@ -64,7 +64,9 @@ class SmbWritableStream extends Writable {
     this.connection = connection
     this.file = file
     this.offset = new Bigint(8, options.start || 0)
-    this.once('finish', () => requestAsync('close', this.file, this.connection));
+    this.once('finish', () => requestAsync('close', this.file, this.connection)
+      .then(() => this.emit('close'), (err) => this.emit('error', err))
+    );
   }
 
   _write (chunk, enc, cb) {

--- a/lib/api/src/createWriteStream.js
+++ b/lib/api/src/createWriteStream.js
@@ -26,65 +26,59 @@ function * fibonacci () {
   }
 }
 
+function writeChunk(buffer, size, start, offset, file, connection, retryGen) {
+  if (offset.ge(size)) {
+    return Promise.resolve();
+  }
+
+  const remainingSize = size.sub(offset);
+  const packetSize = maxPacketSize.lt(remainingSize) ? maxPacketSize : remainingSize;
+  const nextOffset = offset.add(packetSize);
+
+  return requestAsync('write', {
+      FileId: file.FileId,
+      Offset: start.add(offset).toBuffer(),
+      Buffer: buffer.slice(offset.toNumber(), nextOffset.toNumber())
+    }, connection)
+    .catch((err) => {
+      return err.code === 'STATUS_PENDING'
+        ? Promise
+          .delay(retryGen.next().value)
+          .then(writeChunk.bind(undefined, buffer, size, start, offset, file, connection, retryGen))
+        : Promise.reject(err);
+    })
+    .then(writeChunk.bind(undefined, buffer, size, start, nextOffset, file, connection, retryGen));
+}
+
 class SmbWritableStream extends Writable {
   constructor (connection, file, options = {}) {
+    // Respect the encoding option
+    if (options.encoding) {
+      options.defaultEncoding = options.encoding;
+    }
+    // Always decode strings to buffers
+    options.decodeStrings = true;
+
     super(options)
 
-    const {
-      encoding = 'utf8',
-      start = 0
-    } = options
-
     this.connection = connection
-    this.encoding = encoding
     this.file = file
-    this.offset = new Bigint(8, start)
+    this.offset = new Bigint(8, options.start || 0)
+    this.once('finish', () => requestAsync('close', this.file, this.connection));
   }
 
-  async _write (chunk, encoding, next) {
-    encoding = this.encoding || encoding
-    chunk = Buffer.isBuffer(chunk) ? chunk : new Buffer(chunk, encoding)
-
-    while (chunk.length > 0) {
-      const packetSize = Math.min(maxPacketSize.toNumber(), chunk.length)
-      const packet = chunk.slice(0, packetSize)
-      chunk = chunk.slice(packetSize)
-      const offset = new Bigint(this.offset)
-      this.offset = this.offset.add(packetSize)
-
-      const retryInterval = fibonacci()
-      let pending = true
-
-      while (pending) {
-        try {
-          await requestAsync('write', {
-            FileId: this.file.FileId,
-            Offset: offset.toBuffer(),
-            Buffer: packet
-          }, this.connection)
-
-          pending = false
-        } catch (error) {
-          if (error.code === 'STATUS_PENDING') {
-            await new Promise((resolve, reject) => {
-              setTimeout(resolve, retryInterval.next().value)
-            })
-          } else {
-            throw error
-          }
-        }
-      }
-    }
-
-    next()
-  }
-
-  async end (...args) {
-    try {
-      super.end(...args)
-    } finally {
-      await requestAsync('close', this.file, this.connection)
-    }
+  _write (chunk, enc, cb) {
+    writeChunk(
+        chunk,
+        new Bigint(8, chunk.length),
+        new Bigint(this.offset),
+        new Bigint(8, 0),
+        this.file,
+        this.connection,
+        fibonacci()
+      )
+      .then(() => { this.offset = this.offset.add(chunk.length); })
+      .then(cb, cb);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "smb2c",
-  "version": "0.7.5",
+  "name": "@plugandtrade/smb2c",
+  "version": "0.7.6",
   "description": "SMB2 Client from marsaud-smb2 0.7.2 ",
   "engines": [
     "node"
@@ -9,7 +9,7 @@
 
   "repository": {
     "type": "git"
-  , "url": "https://github.com/ccboby/node-samba2"
+  , "url": "https://github.com/PlugAndTrade/node-samba2.git"
   },
 
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugandtrade/smb2c",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "SMB2 Client from marsaud-smb2 0.7.2 ",
   "engines": [
     "node"


### PR DESCRIPTION
The _write function should not be async as an async function will return a promise which may be rejected in case of an error. Since the Writable class does not handle the return value of the _write function any errors will be ignored and the rejected promise will become unhandled.

The end function may be called before all buffers are written to the server. Closing the file in the end function may prevent some data from being written. The file should be closed on the finish event which is emitted once all data is reported as written by the _write function.

It is not necessary handle buffer decoding and encoding since this is done by the Writable class. Setting defaultEncoding and decodeStrings to true will ensure the chunk parameter is a buffer decoded using the defaultEncoding.